### PR TITLE
Add prototype code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ name = "parsec_tpm_direct_se_driver"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-#parsec-client = "0.2.0"
-parsec-client = { version = "0.2.0", path = "../parsec-client-rust" }
+parsec-client = "0.3.0"
 lazy_static = "1.4.0"
 uuid = "0.7.4"
 

--- a/c-tests/main.c
+++ b/c-tests/main.c
@@ -22,7 +22,7 @@ int main()
 	psa_key_handle_t key_pair_handle;
 	psa_key_attributes_t key_pair_attributes = PSA_KEY_ATTRIBUTES_INIT;
 	psa_key_id_t public_key_id = 2;
-	psa_key_handle_t public_key_handle;
+	//psa_key_handle_t public_key_handle;
 	psa_key_attributes_t public_key_attributes = PSA_KEY_ATTRIBUTES_INIT;
 	psa_algorithm_t alg;
 	uint8_t public_key[PSA_KEY_EXPORT_RSA_PUBLIC_KEY_MAX_SIZE(1024)] = {0};
@@ -39,8 +39,8 @@ int main()
 	alg = PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_SHA_256);
 
 	psa_set_key_id(&key_pair_attributes, key_pair_id);
-	//psa_set_key_lifetime(&key_pair_attributes, PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME);
-	psa_set_key_usage_flags(&key_pair_attributes, PSA_KEY_USAGE_SIGN_HASH);
+	psa_set_key_lifetime(&key_pair_attributes, PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME);
+	psa_set_key_usage_flags(&key_pair_attributes, PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH);
 	psa_set_key_algorithm(&key_pair_attributes, alg);
 	psa_set_key_type(&key_pair_attributes, PSA_KEY_TYPE_RSA_KEY_PAIR);
 	psa_set_key_bits(&key_pair_attributes, 1024U);
@@ -52,15 +52,13 @@ int main()
 	psa_set_key_type(&public_key_attributes, PSA_KEY_TYPE_RSA_PUBLIC_KEY);
 	psa_set_key_bits(&public_key_attributes, 1024U);
 
-	/*
-	 * To be activated, need to be executed inside the TPM Docker container
+	// To be activated, need to be executed inside the TPM Docker container
 	status = psa_register_se_driver(PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME,
 			&PARSEC_TPM_DIRECT_SE_DRIVER);
 	if (status != PSA_SUCCESS) {
 		printf("Register failed (status = %d)\n", status);
 		return 1;
 	}
-	*/
 
 	status = psa_crypto_init();
 	if (status != PSA_SUCCESS) {
@@ -83,6 +81,7 @@ int main()
 		return 1;
 	}
 
+	/*
 	status = psa_import_key(&public_key_attributes,
 			public_key,
 			public_key_length,
@@ -91,6 +90,7 @@ int main()
 		printf("Importing key failed (status = %d)\n", status);
 		return 1;
 	}
+	*/
 
 	status = psa_sign_hash(key_pair_handle,
 			alg,
@@ -105,7 +105,8 @@ int main()
 		return 1;
 	}
 
-	status = psa_verify_hash(public_key_handle,
+	//status = psa_verify_hash(public_key_handle,
+	status = psa_verify_hash(key_pair_handle,
 			alg,
 			hash,
 			32,
@@ -122,11 +123,13 @@ int main()
 		return 1;
 	}
 
+	/*
 	status = psa_destroy_key(public_key_handle);
 	if (status != PSA_SUCCESS) {
 		printf("Key destruction failed for Public Key (status = %d)\n", status);
 		return 1;
 	}
+	*/
 
 	return 0;
 }

--- a/src/asymmetric.rs
+++ b/src/asymmetric.rs
@@ -1,11 +1,65 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::psa_se_driver_bindings::psa_drv_se_asymmetric_t;
+use crate::psa_se_driver_bindings::{
+    psa_algorithm_t, psa_drv_se_asymmetric_t, psa_drv_se_context_t, psa_key_slot_number_t,
+    psa_status_t, size_t,
+};
+use crate::PARSEC_BASIC_CLIENT;
+use parsec_client::core::interface::operations::psa_algorithm::{AsymmetricSignature, Hash};
 
 pub(super) static METHODS: psa_drv_se_asymmetric_t = psa_drv_se_asymmetric_t {
-    p_sign: None,
-    p_verify: None,
+    p_sign: Some(p_sign),
+    p_verify: Some(p_verify),
     p_encrypt: None,
     p_decrypt: None,
 };
+
+fn test_alg() -> AsymmetricSignature {
+    AsymmetricSignature::RsaPkcs1v15Sign {
+        hash_alg: Hash::Sha256,
+    }
+}
+
+unsafe extern "C" fn p_sign(
+    _drv_context: *mut psa_drv_se_context_t,
+    _key_slot: psa_key_slot_number_t,
+    _alg: psa_algorithm_t,
+    p_hash: *const u8,
+    hash_length: size_t,
+    p_signature: *mut u8,
+    _signature_size: size_t,
+    p_signature_length: *mut size_t,
+) -> psa_status_t {
+    let key_name = String::from("TEST_KEY");
+    let hash = std::slice::from_raw_parts(p_hash, hash_length as usize).to_vec();
+    let signature = PARSEC_BASIC_CLIENT
+        .read()
+        .unwrap()
+        .psa_sign_hash(key_name, hash, test_alg())
+        .unwrap();
+    let slice: &mut [u8] = std::slice::from_raw_parts_mut(p_signature, signature.len());
+    slice.copy_from_slice(&signature);
+    *p_signature_length = signature.len() as size_t;
+    0
+}
+
+unsafe extern "C" fn p_verify(
+    _drv_context: *mut psa_drv_se_context_t,
+    _key_slot: psa_key_slot_number_t,
+    _alg: psa_algorithm_t,
+    p_hash: *const u8,
+    hash_length: size_t,
+    p_signature: *const u8,
+    signature_length: size_t,
+) -> psa_status_t {
+    let key_name = String::from("TEST_KEY");
+    let hash = std::slice::from_raw_parts(p_hash, hash_length as usize).to_vec();
+    let signature = std::slice::from_raw_parts(p_signature, signature_length as usize).to_vec();
+    PARSEC_BASIC_CLIENT
+        .read()
+        .unwrap()
+        .psa_verify_hash(key_name, hash, test_alg(), signature)
+        .unwrap();
+    0
+}

--- a/src/key_management.rs
+++ b/src/key_management.rs
@@ -1,14 +1,136 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::psa_se_driver_bindings::psa_drv_se_key_management_t;
+use crate::psa_se_driver_bindings::{
+    psa_drv_se_context_t, psa_drv_se_key_management_t, psa_key_attributes_t,
+    psa_key_creation_method_t, psa_key_slot_number_t, psa_status_t, size_t,
+};
+use crate::PARSEC_BASIC_CLIENT;
+use parsec_client::core::interface::operations::psa_algorithm::{
+    Algorithm, AsymmetricSignature, Hash,
+};
+use parsec_client::core::interface::operations::psa_key_attributes::{
+    KeyAttributes, KeyPolicy, KeyType, UsageFlags,
+};
+
+fn test_key_attributes() -> KeyAttributes {
+    KeyAttributes {
+        key_type: KeyType::RsaKeyPair,
+        key_bits: 1024,
+        key_policy: KeyPolicy {
+            key_usage_flags: UsageFlags {
+                sign_hash: true,
+                verify_hash: true,
+                sign_message: false,
+                verify_message: false,
+                export: false,
+                encrypt: false,
+                decrypt: false,
+                cache: false,
+                copy: false,
+                derive: false,
+            },
+            key_algorithm: Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            }),
+        },
+    }
+}
 
 pub(super) static METHODS: psa_drv_se_key_management_t = psa_drv_se_key_management_t {
-    p_allocate: None,
-    p_validate_slot_number: None,
-    p_import: None,
-    p_generate: None,
-    p_destroy: None,
+    p_allocate: Some(p_allocate),
+    p_validate_slot_number: Some(p_validate_slot_number),
+    p_import: Some(p_import),
+    p_generate: Some(p_generate),
+    p_destroy: Some(p_destroy),
     p_export: None,
-    p_export_public: None,
+    p_export_public: Some(p_export_public),
 };
+
+unsafe extern "C" fn p_allocate(
+    _drv_context: *mut psa_drv_se_context_t,
+    _persistent_data: *mut ::std::os::raw::c_void,
+    _attributes: *const psa_key_attributes_t,
+    _method: psa_key_creation_method_t,
+    _key_slot: *mut psa_key_slot_number_t,
+) -> psa_status_t {
+    0
+}
+
+unsafe extern "C" fn p_validate_slot_number(
+    _drv_context: *mut psa_drv_se_context_t,
+    _persistent_data: *mut ::std::os::raw::c_void,
+    _attributes: *const psa_key_attributes_t,
+    _method: psa_key_creation_method_t,
+    _key_slot: psa_key_slot_number_t,
+) -> psa_status_t {
+    0
+}
+
+unsafe extern "C" fn p_import(
+    _drv_context: *mut psa_drv_se_context_t,
+    _key_slot: psa_key_slot_number_t,
+    _attributes: *const psa_key_attributes_t,
+    data: *const u8,
+    data_length: size_t,
+    _bits: *mut size_t,
+) -> psa_status_t {
+    let key_name = String::from("TEST_KEY");
+    let key_material = std::slice::from_raw_parts(data, data_length as usize).to_vec();
+    PARSEC_BASIC_CLIENT
+        .read()
+        .unwrap()
+        .psa_import_key(key_name, key_material, test_key_attributes())
+        .unwrap();
+    0
+}
+
+unsafe extern "C" fn p_generate(
+    _drv_context: *mut psa_drv_se_context_t,
+    _key_slot: psa_key_slot_number_t,
+    _attributes: *const psa_key_attributes_t,
+    _pubkey: *mut u8,
+    _pubkey_size: size_t,
+    _pubkey_length: *mut size_t,
+) -> psa_status_t {
+    let key_name = String::from("TEST_KEY");
+    PARSEC_BASIC_CLIENT
+        .read()
+        .unwrap()
+        .psa_generate_key(key_name, test_key_attributes())
+        .unwrap();
+    0
+}
+
+unsafe extern "C" fn p_destroy(
+    _drv_context: *mut psa_drv_se_context_t,
+    _persistent_data: *mut ::std::os::raw::c_void,
+    _key_slot: psa_key_slot_number_t,
+) -> psa_status_t {
+    let key_name = String::from("TEST_KEY");
+    PARSEC_BASIC_CLIENT
+        .read()
+        .unwrap()
+        .psa_destroy_key(key_name)
+        .unwrap();
+    0
+}
+
+unsafe extern "C" fn p_export_public(
+    _drv_context: *mut psa_drv_se_context_t,
+    _key: psa_key_slot_number_t,
+    p_data: *mut u8,
+    _data_size: size_t,
+    p_data_length: *mut size_t,
+) -> psa_status_t {
+    let key_name = String::from("TEST_KEY");
+    let key_material = PARSEC_BASIC_CLIENT
+        .read()
+        .unwrap()
+        .psa_export_public_key(key_name)
+        .unwrap();
+    let slice: &mut [u8] = std::slice::from_raw_parts_mut(p_data, key_material.len());
+    slice.copy_from_slice(&key_material);
+    *p_data_length = key_material.len() as size_t;
+    0
+}


### PR DESCRIPTION
Hardcodes the key names and the algorithm but is useful for local
testing.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>