### PR TITLE
Replace RSA with ECDSA in the CI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,24 @@ a `psa_drv_se_t` structure.
 
 ## How to build and use the driver
 
-To build you need `tar` and `libclang`:
+When being built, this driver needs to dynamically link with your PSA Crypto
+API implementation that is going to register it.  You need to specify the
+location of libmbedcrypto.so and the `psa/` header files folder with the
+environment variable `MBEDTLS_LIB_DIR` and `MBEDTLS_INCLUDE_DIR`. For example
+if the `mbedtls` project is on the same directory:
+
 ```bash
-$ cargo build
+$ MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build
 ```
-will produce `libparsec_tpm_direct_se_driver.a` (and `.so`) in `target/debug` or `target/release`.
-This library contains the `psa_drv_se_t` symbol defined in the `include/parsec_se_driver.h` file.
-That header file should be included under the same include directory than the PSA `psa/crypto.h`
+
+This will produce `libparsec_tpm_direct_se_driver.a` (and `.so`) in
+`target/debug` or `target/release`.  This library contains the `psa_drv_se_t`
+symbol defined in the `include/parsec_se_driver.h` file.  That header file
+should be included under the same include directory than the PSA `psa/crypto.h`
 file coming from the PSA Cryptography API implementation.
+
+The build scripts have a dependency on `libclang`, which is needed on the
+system.
 
 ## Notice
 

--- a/ci/c-tests/Makefile
+++ b/ci/c-tests/Makefile
@@ -7,7 +7,7 @@ main.o:
 	gcc -Wall -c -I../../include -I$(MBED_TLS_PATH)/include main.c
 
 test-app: main.o
-	gcc -Wall -o test-app main.o -L$(MBED_TLS_PATH)/library -L../../target/debug -l:libparsec_tpm_direct_se_driver.a -lmbedcrypto -lm -pthread -ldl
+	gcc -Wall -o test-app main.o -L$(MBED_TLS_PATH)/library -L../../target/release -l:libparsec_tpm_direct_se_driver.a -lmbedcrypto -lm -pthread -ldl
 
 run: test-app
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(MBED_TLS_PATH)/library ./test-app

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -43,8 +43,8 @@ sleep 5
 # Install and run Parsec
 git clone https://github.com/parallaxsecond/parsec
 pushd parsec
-cargo build --features tpm-provider
-./target/debug/parsec -c ../ci/config.toml &
+cargo build --features tpm-provider --release
+./target/release/parsec -c ../ci/config.toml &
 sleep 5
 popd
 
@@ -59,7 +59,7 @@ popd
 
 # Build the driver, clean before to force dynamic linking
 cargo clean
-MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build
+MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release
 
 # Compile and run the C application
 make -C ci/c-tests run MBED_TLS_PATH=$(pwd)/mbedtls

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod key_management;
 
 use psa_crypto::ffi::{
     psa_drv_se_asymmetric_t, psa_drv_se_context_t, psa_drv_se_key_management_t, psa_drv_se_t,
-    psa_key_lifetime_t, psa_key_slot_number_t, psa_status_t, PSA_DRV_SE_HAL_VERSION,
+    psa_key_location_t, psa_key_slot_number_t, psa_status_t, PSA_DRV_SE_HAL_VERSION,
 };
 use psa_crypto::ffi::{
     PSA_ERROR_ALREADY_EXISTS,
@@ -101,8 +101,7 @@ pub static mut PARSEC_TPM_DIRECT_SE_DRIVER: psa_drv_se_t = psa_drv_se_t {
 unsafe extern "C" fn p_init(
     _drv_context: *mut psa_drv_se_context_t,
     _persistent_data: *mut ::std::os::raw::c_void,
-    //_location: psa_key_location_t,
-    _location: psa_key_lifetime_t,
+    _location: psa_key_location_t,
 ) -> psa_status_t {
     let mut client = (*PARSEC_BASIC_CLIENT).write().expect("lock poisoned");
 


### PR DESCRIPTION
Also uses the release versions of the driver and Parsec to test. Specify
the instructions in the README.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>