### PR TITLE
Use a specific commit compatible with 2.22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ psa-crypto = "0.1.0"
 log = "0.4.8"
 env_logger = { version = "0.7.1", optional = true }
 
+# Use a revision of psa-crypto-sys that is linkable with Mbed TLS 2.22.0 until a next
+# version is updated.
+[patch.crates-io]
+psa-crypto-sys = { git = 'https://github.com/parallaxsecond/rust-psa-crypto', rev = "b8e1d736cb8f27d275d266a0b833504cde660956" }
+
 [build-dependencies]
 curl = "0.4.28"
 bindgen = "0.53.2"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ file coming from the PSA Cryptography API implementation.
 The build scripts have a dependency on `libclang`, which is needed on the
 system.
 
+The driver has only been tested with Mbed Crypto from the GitHub Mbed TLS repository version
+2.22.0.
+
 ## Notice
 
 This implementation is currently work-in-progress and might not implement all operations or
@@ -37,7 +40,6 @@ parameters of the HAL.
 The driver produced currently hardcodes the following parameters:
 * it uses the TPM provider
 * it uses direct authentication
-* it expects the Mbed Crypto implementation from Mbed TLS version `MBED_TLS_VERSION` in `build.rs`
 
 ## License
 

--- a/ci/c-tests/main.c
+++ b/ci/c-tests/main.c
@@ -20,24 +20,20 @@ int main()
 	psa_status_t status;
 	psa_key_id_t key_pair_id = 1;
 	psa_key_handle_t key_pair_handle;
-	psa_key_id_t public_key_id = 2;
-	//psa_key_handle_t public_key_handle;
 	psa_algorithm_t alg;
 	uint8_t public_key[PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(256)] = {0};
-	//uint8_t public_key[PSA_EXPORT_PUBLIC_KEY_OUTPUT_SIZE(PSA_KEY_TYPE_RSA_KEY_PAIR, 1024U)] = {0};
 	size_t public_key_length = 0;
 	// "Les carottes sont cuites" hased with SHA256
 	uint8_t hash[32] = {0xd8, 0xd2, 0xf7, 0x77, 0x79, 0x76, 0x6d, 0x13, 0x1c, 0x8e, 0x06, 0x06,
 		0xde, 0x0d, 0xb1, 0xc1, 0x9b, 0xe0, 0x21, 0xb5, 0xfa, 0x74, 0x83, 0x08, 0x3b, 0xda, 0x5e,
 		0xf3, 0x51, 0x32, 0xc7, 0x02};
 	uint8_t signature[PSA_SIGNATURE_MAX_SIZE] = {0};
-	//uint8_t signature[PSA_SIGN_OUTPUT_SIZE(PSA_KEY_TYPE_RSA_KEY_PAIR, 1024U, alg)] = {0};
 	size_t signature_length = 0;
 
 	alg = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
 
 	// To be activated, need to be executed inside the TPM Docker container
-	status = psa_register_se_driver(PSA_KEY_LIFETIME_GET_LOCATION(PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME),
+	status = psa_register_se_driver(PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME,
 			&PARSEC_TPM_DIRECT_SE_DRIVER);
 	if (status != PSA_SUCCESS) {
 		printf("Register failed (status = %d)\n", status);
@@ -58,14 +54,6 @@ int main()
 	psa_set_key_type(&key_pair_attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP_R1));
 	psa_set_key_bits(&key_pair_attributes, 256U);
 
-	psa_key_attributes_t public_key_attributes = PSA_KEY_ATTRIBUTES_INIT;
-	psa_set_key_id(&public_key_attributes, public_key_id);
-	psa_set_key_lifetime(&public_key_attributes, PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME);
-	psa_set_key_usage_flags(&public_key_attributes, PSA_KEY_USAGE_VERIFY_HASH);
-	psa_set_key_algorithm(&public_key_attributes, alg);
-	psa_set_key_type(&public_key_attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP_R1));
-	psa_set_key_bits(&public_key_attributes, 256U);
-
 	status = psa_generate_key(&key_pair_attributes, &key_pair_handle);
 	if (status != PSA_SUCCESS) {
 		printf("Key generation failed (status = %d)\n", status);
@@ -81,23 +69,11 @@ int main()
 		return 1;
 	}
 
-	/*
-	status = psa_import_key(&public_key_attributes,
-			public_key,
-			public_key_length,
-			&public_key_handle);
-	if (status != PSA_SUCCESS) {
-		printf("Importing key failed (status = %d)\n", status);
-		return 1;
-	}
-	*/
-
 	status = psa_sign_hash(key_pair_handle,
 			alg,
 			hash,
 			sizeof(hash),
 			signature,
-			//PSA_SIGN_OUTPUT_SIZE(PSA_KEY_TYPE_RSA_KEY_PAIR, 1024U, alg),
 			PSA_SIGNATURE_MAX_SIZE,
 			&signature_length);
 	if (status != PSA_SUCCESS) {
@@ -121,14 +97,6 @@ int main()
 		printf("Key destruction failed for Key PAIR (status = %d)\n", status);
 		return 1;
 	}
-
-	/*
-	status = psa_destroy_key(public_key_handle);
-	if (status != PSA_SUCCESS) {
-		printf("Key destruction failed for Public Key (status = %d)\n", status);
-		return 1;
-	}
-	*/
 
 	return 0;
 }

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -51,7 +51,7 @@ popd
 # Compile Mbed Crypto
 git clone https://github.com/ARMmbed/mbedtls.git
 pushd mbedtls
-git checkout a7f6d25e12158f0062bc0e2cf994fafe5daf2e68
+git checkout mbedtls-2.22.0
 ./scripts/config.py crypto
 ./scripts/config.py set MBEDTLS_PSA_CRYPTO_SE_C
 SHARED=1 make

--- a/ci/config.toml
+++ b/ci/config.toml
@@ -1,5 +1,5 @@
 [core_settings]
-log_level = "info"
+log_level = "trace"
 # The CI already timestamps the logs
 log_timestamp = false
 

--- a/include/parsec_se_driver.h
+++ b/include/parsec_se_driver.h
@@ -7,9 +7,7 @@
 #include "psa/crypto_se_driver.h"
 
 // Parsec SE Driver implementation using the TPM provider and direct authentication.
-// This value is compatible with lifetime seen as a combination of location and persistence.
-// The location is 0x000001 (primary SE) and persistence is 0x01 (persistent).
-#define PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME ((psa_key_lifetime_t)0x00000101)
+#define PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME ((psa_key_lifetime_t)0x00000002)
 extern psa_drv_se_t PARSEC_TPM_DIRECT_SE_DRIVER;
 
 #endif /* PARSEC_SE_DRIVER_H */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod key_management;
 
 use psa_crypto::ffi::{
     psa_drv_se_asymmetric_t, psa_drv_se_context_t, psa_drv_se_key_management_t, psa_drv_se_t,
-    psa_key_location_t, psa_key_slot_number_t, psa_status_t, PSA_DRV_SE_HAL_VERSION,
+    psa_key_lifetime_t, psa_key_slot_number_t, psa_status_t, PSA_DRV_SE_HAL_VERSION,
 };
 use psa_crypto::ffi::{
     PSA_ERROR_ALREADY_EXISTS,
@@ -102,12 +102,14 @@ pub static mut PARSEC_TPM_DIRECT_SE_DRIVER: psa_drv_se_t = psa_drv_se_t {
 unsafe extern "C" fn p_init(
     _drv_context: *mut psa_drv_se_context_t,
     _persistent_data: *mut ::std::os::raw::c_void,
-    _location: psa_key_location_t,
+    _location: psa_key_lifetime_t,
 ) -> psa_status_t {
     let mut client = (*PARSEC_BASIC_CLIENT).write().expect("lock poisoned");
 
     #[cfg(logging)]
     env_logger::init();
+
+    log::info!("SE Driver initialization");
 
     let providers = match client.list_providers() {
         Ok(providers) => providers,


### PR DESCRIPTION
This commit makes the SE driver work with Mbed TLS 2.22.0 until a new
version of the `psa-crypto` crate is published.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>