### PR TITLE
Make the SE driver provider-agnostic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,15 @@
 arch: arm64
 language: rust
 script:
-  - cargo build
+# Compile Mbed Crypto for the test application
+  - git clone https://github.com/ARMmbed/mbedtls.git
+  - pushd mbedtls
+  - git checkout mbedtls-2.22.0
+  - ./scripts/config.py crypto
+  - ./scripts/config.py set MBEDTLS_PSA_CRYPTO_SE_C
+  - SHARED=1 make
+  - popd
+# Build the driver, clean before to force dynamic linking
+  - cargo clean
+# Remove the socket permission check on the CI to not have to setup the service properly
+  - MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,15 @@ categories = ["development-tools"]
 edition = "2018"
 documentation = "https://parallaxsecond.github.io/"
 
-# Currently this library hardcodes the provider and the authentication method choices:
-#   * provider is TPM
-#   * authentication is direct authentication
 [lib]
-name = "parsec_tpm_direct_se_driver"
+name = "parsec_se_driver"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-parsec-client = "0.5.0"
+parsec-client = "0.7.0"
 lazy_static = "1.4.0"
 uuid = "0.7.4"
-psa-crypto = "0.2.0"
+psa-crypto = { version = "0.3.0", default-features = false, features = ["interface"] }
 log = "0.4.8"
 env_logger = { version = "0.7.1", optional = true }
 
@@ -35,3 +32,5 @@ bindgen = "0.53.2"
 [features]
 default = ["logging"]
 logging = ["env_logger"]
+tpm = []
+pkcs11 = []

--- a/README.md
+++ b/README.md
@@ -10,21 +10,26 @@ a `psa_drv_se_t` structure.
 
 ## How to build and use the driver
 
-When being built, this driver needs to dynamically link with your PSA Crypto
-API implementation that is going to register it.  You need to specify the
-location of libmbedcrypto.so and the `psa/` header files folder with the
-environment variable `MBEDTLS_LIB_DIR` and `MBEDTLS_INCLUDE_DIR`. For example
-if the `mbedtls` project is on the same directory:
+When being built, this driver needs to use the same PSA Crypto API interface
+implementation that is going to register it.  You need to specify the location
+of `psa/` header files folder with the environment variable
+`MBEDTLS_INCLUDE_DIR`. For example if the `mbedtls` project is on the same
+directory:
 
 ```bash
-$ MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build
+$ MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build
 ```
 
-This will produce `libparsec_tpm_direct_se_driver.a` (and `.so`) in
+This will produce `libparsec_se_driver.a` (and `.so`) in
 `target/debug` or `target/release`.  This library contains the `psa_drv_se_t`
 symbol defined in the `include/parsec_se_driver.h` file.  That header file
 should be included under the same include directory than the PSA `psa/crypto.h`
 file coming from the PSA Cryptography API implementation.
+
+By default, this SE Driver will make its requests using the Parsec Provider
+with the highest priority. If you would like it to always select a specific provider,
+use the `pkcs11` feature for the PKCS11 provider or the `tpm` feature for the TPM provider.
+If both features are enabled, the `tpm` one will take precedence.
 
 The build scripts have a dependency on `libclang`, which is needed on the
 system.
@@ -37,9 +42,23 @@ The driver has only been tested with Mbed Crypto from the GitHub Mbed TLS reposi
 This implementation is currently work-in-progress and might not implement all operations or
 parameters of the HAL.
 
-The driver produced currently hardcodes the following parameters:
-* it uses the TPM provider
-* it uses direct authentication
+The driver produced currently uses direct authentication with Parsec. The
+application name of requests made to Parsec by this SE driver will be "Parsec
+SE Driver". Make sure to check the
+[Parsec](https://parallaxsecond.github.io/parsec-book/threat_model/threat_model.html)
+and [Parsec Rust
+Client](https://parallaxsecond.github.io/parsec-book/threat_model/rust_client_threat_model.html)
+threat models to make sure that your use-case is secure.
+
+## Testing
+
+The Parsec Client used by the SE Driver will make filesystem permission checks on the Parsec
+socket. During testing, to not have to set up the correct secure Parsec environment, pass
+the `no-fs-permission-check` feature to `parsec-client`:
+
+```bash
+MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --features parsec-client/no-fs-permission-check
+```
 
 ## License
 

--- a/ci/c-tests/Makefile
+++ b/ci/c-tests/Makefile
@@ -7,7 +7,7 @@ main.o:
 	gcc -Wall -c -I../../include -I$(MBED_TLS_PATH)/include main.c
 
 test-app: main.o
-	gcc -Wall -o test-app main.o -L$(MBED_TLS_PATH)/library -L../../target/release -l:libparsec_tpm_direct_se_driver.a -lmbedcrypto -lm -pthread -ldl
+	gcc -Wall -o test-app main.o -L$(MBED_TLS_PATH)/library -L../../target/release -l:libparsec_se_driver.a -lmbedcrypto -lm -pthread -ldl
 
 run: test-app
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(MBED_TLS_PATH)/library ./test-app

--- a/ci/c-tests/main.c
+++ b/ci/c-tests/main.c
@@ -33,8 +33,8 @@ int main()
 	alg = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
 
 	// To be activated, need to be executed inside the TPM Docker container
-	status = psa_register_se_driver(PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME,
-			&PARSEC_TPM_DIRECT_SE_DRIVER);
+	status = psa_register_se_driver(PARSEC_SE_DRIVER_LIFETIME,
+			&PARSEC_SE_DRIVER);
 	if (status != PSA_SUCCESS) {
 		printf("Register failed (status = %d)\n", status);
 		return 1;
@@ -48,7 +48,7 @@ int main()
 
 	psa_key_attributes_t key_pair_attributes = PSA_KEY_ATTRIBUTES_INIT;
 	psa_set_key_id(&key_pair_attributes, key_pair_id);
-	psa_set_key_lifetime(&key_pair_attributes, PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME);
+	psa_set_key_lifetime(&key_pair_attributes, PARSEC_SE_DRIVER_LIFETIME);
 	psa_set_key_usage_flags(&key_pair_attributes, PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH);
 	psa_set_key_algorithm(&key_pair_attributes, alg);
 	psa_set_key_type(&key_pair_attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP_R1));

--- a/include/parsec_se_driver.h
+++ b/include/parsec_se_driver.h
@@ -6,8 +6,7 @@
 
 #include "psa/crypto_se_driver.h"
 
-// Parsec SE Driver implementation using the TPM provider and direct authentication.
-#define PARSEC_TPM_DIRECT_SE_DRIVER_LIFETIME ((psa_key_lifetime_t)0x00000002)
-extern psa_drv_se_t PARSEC_TPM_DIRECT_SE_DRIVER;
+#define PARSEC_SE_DRIVER_LIFETIME ((psa_key_lifetime_t)0x00000002)
+extern psa_drv_se_t PARSEC_SE_DRIVER;
 
 #endif /* PARSEC_SE_DRIVER_H */


### PR DESCRIPTION
The SE Driver was only targeting the TPM provider. This behaviour has
been changed to be provider-agnostic: by default the SE driver will
target the highest priority provider returned by the ListProviders
operation. Features are introduced to also have a way to select a single
provider.

This commit also pull the newest psa-crypto with the new `interface`
feature. This SE driver does not need to link with the PSA Crypto
implementation but only needs the interface implementation.

Fix #7

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>