### PR TITLE
Update dependencies for Mbed TLS 2.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "parsec-se-driver"
-version = "0.4.0"
-authors = ["Paul Howard <paul.howard@arm.com>",
-           "Ionut Mihalcea <ionut.mihalcea@arm.com>",
-           "Hugues de Valon <hugues.devalon@arm.com>"]
+version = "0.5.0"
+authors = ["Contributors to the Parsec project"]
 description = "Parsec Secure Element driver implementation"
 license = "Apache-2.0"
 repository = "https://github.com/parallaxsecond/parsec-se-driver"
@@ -15,17 +13,15 @@ documentation = "https://parallaxsecond.github.io/"
 
 [lib]
 name = "parsec_se_driver"
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["staticlib"]
 
 [dependencies]
-parsec-client = "0.11.0"
+parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust", rev = "f2470712b2cbf854a7b2e5036f1c8c7cf889dfa6" }
 lazy_static = "1.4.0"
-psa-crypto = { version = "0.6.0", default-features = false, features = ["interface"] }
+psa-crypto = { git = "https://github.com/parallaxsecond/rust-psa-crypto", rev = "4da203be2d4ec0705fb87234468612011b452861", default-features = false, features = ["interface"] }
 log = "0.4.11"
 env_logger = { version = "0.7.1", optional = true }
 
 [features]
 default = ["logging"]
 logging = ["env_logger"]
-tpm = []
-pkcs11 = []

--- a/README.md
+++ b/README.md
@@ -20,24 +20,20 @@ directory:
 $ MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build
 ```
 
-This will produce `libparsec_se_driver.a` (and `.so`) in
+This will produce `libparsec_se_driver.a` in
 `target/debug` or `target/release`.  This library contains the `psa_drv_se_t`
 symbol defined in the `include/parsec_se_driver.h` file.  That header file
 should be included under the same include directory than the PSA `psa/crypto.h`
 file coming from the PSA Cryptography API implementation.
 
-By default, this SE Driver will make its requests using the Parsec Provider
-with the highest priority. If you would like it to always select a specific provider,
-use the `pkcs11` feature for the PKCS11 provider or the `tpm` feature for the TPM provider.
-If both features are enabled, the `tpm` one will take precedence.
-
 The build scripts have a dependency on `libclang`, which is needed on the
 system.
 
-The driver has only been tested with Mbed Crypto from the GitHub Mbed TLS repository version
-2.22.0.
+Version `0.4.0` of this SE driver is compatible with Parsec version `0.6.0` and has
+been tested with Mbed Crypto from the GitHub Mbed TLS repository version 2.22.0.
+Version `0.5.0` of this SE driver is compatible with Parsec version `0.6.0` and has
+been tested with Mbed Crypto from the GitHub Mbed TLS repository version 2.25.0.
 
-The current version of this SE driver (`0.4.0`) is compatible with Parsec version `0.6.0`.
 For compatibility of older versions, check which Parsec service version was used in the `ci/ci.sh`
 script for those SE driver versions.
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -18,8 +18,10 @@ RUN cd tpm2-tools \
 	&& ./configure --enable-unit \
 	&& make install
 
-RUN apt-get update && apt-get -y install \
-	cmake
+RUN apt update && apt -y install cmake
+RUN apt -y install gcc-multilib
+RUN apt -y install gcc-arm-linux-gnueabihf
+RUN apt -y install gcc-aarch64-linux-gnu
 
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y

--- a/ci/c-tests/Makefile
+++ b/ci/c-tests/Makefile
@@ -10,7 +10,7 @@ test-app: main.o
 	gcc -Wall -o test-app main.o -L$(MBED_TLS_PATH)/library -L../../target/release -l:libparsec_se_driver.a -lmbedcrypto -lm -pthread -ldl
 
 run: test-app
-	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(MBED_TLS_PATH)/library ./test-app
+	RUST_LOG=info LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(MBED_TLS_PATH)/library ./test-app
 
 clean:
 	rm -rf test-app main.o

--- a/ci/c-tests/main.c
+++ b/ci/c-tests/main.c
@@ -33,7 +33,8 @@ int main()
 	alg = PSA_ALG_ECDSA(PSA_ALG_SHA_256);
 
 	// To be activated, need to be executed inside the TPM Docker container
-	status = psa_register_se_driver(PARSEC_SE_DRIVER_LIFETIME,
+	// PSA_KEY_LOCATION_PRIMARY_SECURE_ELEMENT is not defined in 2.25.0
+	status = psa_register_se_driver((psa_key_location_t)0x000001,
 			&PARSEC_SE_DRIVER);
 	if (status != PSA_SUCCESS) {
 		printf("Register failed (status = %d)\n", status);
@@ -48,7 +49,8 @@ int main()
 
 	psa_key_attributes_t key_pair_attributes = PSA_KEY_ATTRIBUTES_INIT;
 	psa_set_key_id(&key_pair_attributes, key_pair_id);
-	psa_set_key_lifetime(&key_pair_attributes, PARSEC_SE_DRIVER_LIFETIME);
+	psa_set_key_lifetime(&key_pair_attributes,
+			             PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_PERSISTENCE_DEFAULT, (psa_key_location_t)0x000001));
 	psa_set_key_usage_flags(&key_pair_attributes, PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH);
 	psa_set_key_algorithm(&key_pair_attributes, alg);
 	psa_set_key_type(&key_pair_attributes, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP_R1));

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -14,7 +14,7 @@ then
 	git clone https://github.com/ARMmbed/mbedtls.git
 fi
 pushd mbedtls
-git checkout mbedtls-2.22.0
+git checkout mbedtls-2.25.0
 popd
 
 #################
@@ -59,6 +59,11 @@ popd
 
 # Build the driver, clean before to force dynamic linking
 cargo clean
+# Cross-compilation targets
+rustup target add armv7-unknown-linux-gnueabihf
+rustup target add aarch64-unknown-linux-gnu
+MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release --target armv7-unknown-linux-gnueabihf
+MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release --target aarch64-unknown-linux-gnu
 MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release
 
 # Compile and run the C application

--- a/include/parsec_se_driver.h
+++ b/include/parsec_se_driver.h
@@ -6,7 +6,6 @@
 
 #include "psa/crypto_se_driver.h"
 
-#define PARSEC_SE_DRIVER_LIFETIME ((psa_key_lifetime_t)0x00000002)
 extern psa_drv_se_t PARSEC_SE_DRIVER;
 
 #endif /* PARSEC_SE_DRIVER_H */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,48 +38,33 @@ mod key_management;
 
 use psa_crypto::ffi::{
     psa_drv_se_asymmetric_t, psa_drv_se_context_t, psa_drv_se_key_management_t, psa_drv_se_t,
-    psa_key_lifetime_t, psa_key_slot_number_t, psa_status_t,
+    psa_key_location_t, psa_key_slot_number_t, psa_status_t,
 };
 use psa_crypto::ffi::{
-    PSA_ERROR_ALREADY_EXISTS,
-    PSA_ERROR_BAD_STATE,
-    PSA_ERROR_BUFFER_TOO_SMALL,
-    PSA_ERROR_COMMUNICATION_FAILURE,
-    PSA_ERROR_DOES_NOT_EXIST,
-    PSA_ERROR_GENERIC_ERROR,
-    //PSA_ERROR_DATA_CORRUPT,
-    //PSA_ERROR_DATA_INVALID,
-    PSA_ERROR_HARDWARE_FAILURE,
-    PSA_ERROR_INSUFFICIENT_DATA,
-    //PSA_ERROR_CORRUPTION_DETECTED,
-    PSA_ERROR_INSUFFICIENT_ENTROPY,
-    PSA_ERROR_INSUFFICIENT_MEMORY,
-    PSA_ERROR_INSUFFICIENT_STORAGE,
-    PSA_ERROR_INVALID_ARGUMENT,
-    PSA_ERROR_INVALID_HANDLE,
-    PSA_ERROR_INVALID_PADDING,
-    PSA_ERROR_INVALID_SIGNATURE,
-    PSA_ERROR_NOT_PERMITTED,
-    PSA_ERROR_NOT_SUPPORTED,
-    PSA_ERROR_STORAGE_FAILURE,
-    PSA_SUCCESS,
+    PSA_ERROR_ALREADY_EXISTS, PSA_ERROR_BAD_STATE, PSA_ERROR_BUFFER_TOO_SMALL,
+    PSA_ERROR_COMMUNICATION_FAILURE, PSA_ERROR_DOES_NOT_EXIST, PSA_ERROR_GENERIC_ERROR,
+    PSA_ERROR_HARDWARE_FAILURE, PSA_ERROR_INSUFFICIENT_DATA, PSA_ERROR_INSUFFICIENT_ENTROPY,
+    PSA_ERROR_INSUFFICIENT_MEMORY, PSA_ERROR_INSUFFICIENT_STORAGE, PSA_ERROR_INVALID_ARGUMENT,
+    PSA_ERROR_INVALID_HANDLE, PSA_ERROR_INVALID_PADDING, PSA_ERROR_INVALID_SIGNATURE,
+    PSA_ERROR_NOT_PERMITTED, PSA_ERROR_NOT_SUPPORTED, PSA_ERROR_STORAGE_FAILURE, PSA_SUCCESS,
 };
 
 use lazy_static::lazy_static;
-use log::error;
-use parsec_client::core::interface::operations::list_providers::Uuid;
+use log::{error, info};
 use parsec_client::core::interface::requests::ResponseStatus;
 use parsec_client::error::Error;
 use parsec_client::BasicClient;
 use std::ptr;
 use std::sync::RwLock;
-use std::time::Duration;
 
 lazy_static! {
+    // We do not use "new" directly here because it can fail and we do not want to panic. The
+    // automatic selection of authentication/provider is done in `p_init` so that we can return an
+    // error if there is a problem with that.
     static ref PARSEC_BASIC_CLIENT: RwLock<BasicClient> = RwLock::new(BasicClient::new_naked());
 }
 
-/// SE Driver implementation which hardcodes the authentication method (direct authentication).
+/// Parsec SE Driver structure
 #[no_mangle]
 pub static mut PARSEC_SE_DRIVER: psa_drv_se_t = psa_drv_se_t {
     hal_version: 5,
@@ -96,50 +81,25 @@ pub static mut PARSEC_SE_DRIVER: psa_drv_se_t = psa_drv_se_t {
 unsafe extern "C" fn p_init(
     _drv_context: *mut psa_drv_se_context_t,
     _persistent_data: *mut ::std::os::raw::c_void,
-    _location: psa_key_lifetime_t,
+    _location: psa_key_location_t,
 ) -> psa_status_t {
-    let mut client = (*PARSEC_BASIC_CLIENT).write().expect("lock poisoned");
-
     #[cfg(feature = "logging")]
     // Ignore if the initialisation failed because the `p_init` function has already been called.
     let _ = env_logger::try_init();
 
-    log::info!("SE Driver initialization");
-
-    client.set_timeout(Some(Duration::new(5, 0)));
+    let mut client = (*PARSEC_BASIC_CLIENT).write().expect("lock poisoned");
 
     if let Err(e) = client.set_default_auth(Some(String::from("Parsec SE Driver"))) {
         error!("Error setting the default authentication method ({}).", e);
         return PSA_ERROR_GENERIC_ERROR;
     }
 
-    let providers = match client.list_providers() {
-        Ok(providers) => providers,
-        Err(e) => {
-            error!("error getting available providers: {:?}.", e);
-            return PSA_ERROR_GENERIC_ERROR;
-        }
-    };
-    let provider_id = match providers.iter().find(|p| {
-        if cfg!(feature = "tpm") {
-            // Only keep the TPM provider.
-            p.uuid == Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap()
-        } else if cfg!(feature = "pkcs11") {
-            // Only keep the PKCS11 provider.
-            p.uuid == Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap()
-        } else {
-            // Filter the Core provider.
-            p.uuid != Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap()
-        }
-    }) {
-        Some(provider) => provider.id,
-        None => {
-            error!("The SE Driver could not find any suitable Parsec provider.");
-            return PSA_ERROR_GENERIC_ERROR;
-        }
-    };
+    if let Err(e) = client.set_default_provider() {
+        error!("Error setting the default provider ({}).", e);
+        return PSA_ERROR_GENERIC_ERROR;
+    }
 
-    client.set_implicit_provider(provider_id);
+    info!("SE Driver initialized");
 
     PSA_SUCCESS
 }


### PR DESCRIPTION
Also adds tests for cross-compilation.
Removes the features as in most use-cases, the default provider will be
used.

Fix #17 
Fix #21 
