### PR TITLE
Remove warning message about Parsec compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,27 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run the container to execute the test script
         run: docker run -v $(pwd):/tmp/parsec-se-driver -w /tmp/parsec-se-driver ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec-se-driver/ci/ci.sh
+
+  cross-compilation:
+    name: Cross-compile to various targets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Download Mbed Crypto
+        run: git clone -b mbedtls-2.25.0 https://github.com/ARMmbed/mbedtls.git
+      - name: armv7-unknown-linux-gnueabihf
+        run: |
+          rustup target add armv7-unknown-linux-gnueabihf
+          sudo apt install -y gcc-multilib
+          sudo apt install -y gcc-arm-linux-gnueabihf
+          MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release --target armv7-unknown-linux-gnueabihf
+      - name: aarch64-unknown-linux-gnu
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+          sudo apt install -y gcc-aarch64-linux-gnu
+          MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release --target aarch64-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -1,63 +1,55 @@
-<!--
-  -- Copyright 2020 Contributors to the Parsec project. 
-  -- SPDX-License-Identifier: Apache-2.0
---->
 # Parsec Secure Element Driver
 
-This repository contains an implementation of a PSA Secure Element using the [Parsec service](https://github.com/parallaxsecond/parsec).
-It implements the Secure Element Hardware Abstraction Layer and compiles to a library exposing
-a `psa_drv_se_t` structure.
+This repository contains an implementation of a PSA Secure Element using the [Parsec
+service](https://github.com/parallaxsecond/parsec). It implements the Secure Element Hardware
+Abstraction Layer and compiles to a library exposing a `psa_drv_se_t` structure.
 
 ## How to build and use the driver
 
-When being built, this driver needs to use the same PSA Crypto API interface
-implementation that is going to register it.  You need to specify the location
-of `psa/` header files folder with the environment variable
-`MBEDTLS_INCLUDE_DIR`. For example if the `mbedtls` project is on the same
+When being built, this driver needs to use the same PSA Crypto API interface implementation that is
+going to register it. You need to specify the location of `psa/` header files folder with the
+environment variable `MBEDTLS_INCLUDE_DIR`. For example if the `mbedtls` project is on the same
 directory:
 
-```bash
+```
 $ MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build
 ```
 
-This will produce `libparsec_se_driver.a` in
-`target/debug` or `target/release`.  This library contains the `psa_drv_se_t`
-symbol defined in the `include/parsec_se_driver.h` file.  That header file
-should be included under the same include directory than the PSA `psa/crypto.h`
-file coming from the PSA Cryptography API implementation.
+This will produce `libparsec_se_driver.a` in `target/debug` or `target/release`. This library
+contains the `psa_drv_se_t` symbol defined in the `include/parsec_se_driver.h` file. That header
+file should be included under the same include directory than the PSA `psa/crypto.h` file coming
+from the PSA Cryptography API implementation.
 
-The build scripts have a dependency on `libclang`, which is needed on the
-system.
+The build scripts have a dependency on `libclang`, which is needed on the system.
 
-Version `0.4.0` of this SE driver is compatible with Parsec version `0.6.0` and has
-been tested with Mbed Crypto from the GitHub Mbed TLS repository version 2.22.0.
-Version `0.5.0` of this SE driver is compatible with Parsec version `0.6.0` and has
-been tested with Mbed Crypto from the GitHub Mbed TLS repository version 2.25.0.
-
-For compatibility of older versions, check which Parsec service version was used in the `ci/ci.sh`
-script for those SE driver versions.
+Version `0.4.0` of this SE driver has been tested with Mbed Crypto from the GitHub Mbed TLS
+repository version 2.22.0. Version `0.5.0` of this SE driver has been tested with Mbed Crypto from
+the GitHub Mbed TLS repository version 2.25.0.
 
 ## Notice
 
 This implementation is currently work-in-progress and might not implement all operations or
 parameters of the HAL.
 
-The driver produced currently uses Parsec default authentication method.
-If Parsec is using the Direct authenticator, the
-application name of requests made to Parsec by this SE driver will be "Parsec
-SE Driver".
+The driver produced currently uses Parsec default authentication method. If Parsec is using the
+Direct authenticator, the application name of requests made to Parsec by this SE driver will be
+"Parsec SE Driver".
 
 Make sure to check the
-[Parsec](https://parallaxsecond.github.io/parsec-book/threat_model/threat_model.html)
-and [Parsec Rust
+[Parsec](https://parallaxsecond.github.io/parsec-book/threat_model/threat_model.html) and [Parsec
+Rust
 Client](https://parallaxsecond.github.io/parsec-book/threat_model/rust_client_threat_model.html)
 threat models to make sure that your use-case is secure.
 
 ## License
 
-The software is provided under Apache-2.0. Contributions to this project are accepted under the same license.
+The software is provided under Apache-2.0. Contributions to this project are accepted under the same
+license.
 
 ## Contributing
 
-Please check the [**Contribution Guidelines**](https://parallaxsecond.github.io/parsec-book/contributing.html)
-to know more about the contribution process.
+Please check the [**Contribution
+Guidelines**](https://parallaxsecond.github.io/parsec-book/contributing.html) to know more about the
+contribution process.
+
+*Copyright 2020 Contributors to the Parsec project.*

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -59,11 +59,6 @@ popd
 
 # Build the driver, clean before to force dynamic linking
 cargo clean
-# Cross-compilation targets
-rustup target add armv7-unknown-linux-gnueabihf
-rustup target add aarch64-unknown-linux-gnu
-MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release --target armv7-unknown-linux-gnueabihf
-MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release --target aarch64-unknown-linux-gnu
 MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release
 
 # Compile and run the C application


### PR DESCRIPTION
The SE driver should work with any version of Parsec. This will need to
be tested later on. Only keep the Mbed TLS versions.