### PR TITLE
Update dependencies and code for Mbed TLS 2.27.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Download Mbed Crypto
-        run: git clone -b mbedtls-2.25.0 https://github.com/ARMmbed/mbedtls.git
+        run: git clone -b mbedtls-2.27.0 https://github.com/ARMmbed/mbedtls.git
       - name: armv7-unknown-linux-gnueabihf
         run: |
           rustup target add armv7-unknown-linux-gnueabihf

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
 # Compile Mbed Crypto for the test application
   - git clone https://github.com/ARMmbed/mbedtls.git
   - pushd mbedtls
-  - git checkout mbedtls-2.22.0
+  - git checkout mbedtls-2.27.0
   - ./scripts/config.py crypto
   - ./scripts/config.py set MBEDTLS_PSA_CRYPTO_SE_C
   - SHARED=1 make

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ name = "parsec_se_driver"
 crate-type = ["staticlib"]
 
 [dependencies]
-parsec-client = "0.12.0"
+parsec-client = "0.13.0"
 lazy_static = "1.4.0"
-psa-crypto = { version = "0.8.0", default-features = false, features = ["interface"] }
+psa-crypto = { version = "0.9.0", default-features = false, features = ["interface"] }
 log = "0.4.11"
 env_logger = { version = "0.7.1", optional = true }
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -14,7 +14,7 @@ then
 	git clone https://github.com/ARMmbed/mbedtls.git
 fi
 pushd mbedtls
-git checkout mbedtls-2.25.0
+git checkout mbedtls-2.27.0
 popd
 
 #################
@@ -32,12 +32,12 @@ fi
 # C Tests #
 ###########
 
-# Start the TPM server
+cp /tmp/NVChip .
+# Start and configure TPM server
 tpm_server &
 sleep 5
-tpm2_startup -c 2>/dev/null
-tpm2_takeownership -o tpm_pass 2>/dev/null
-sleep 5
+# Ownership has already been taken with "tpm_pass".
+tpm2_startup -T mssim
 
 # Create the Parsec socket directory. This must be the default one.
 mkdir /run/parsec

--- a/src/asymmetric.rs
+++ b/src/asymmetric.rs
@@ -31,7 +31,7 @@ unsafe extern "C" fn p_sign(
         Err(e) => return e.into(),
     };
     let signature = match PARSEC_BASIC_CLIENT.read().unwrap().psa_sign_hash(
-        key_slot_to_key_name(key_slot),
+        &key_slot_to_key_name(key_slot),
         std::slice::from_raw_parts(p_hash, hash_length),
         alg,
     ) {
@@ -59,7 +59,7 @@ unsafe extern "C" fn p_verify(
         Err(e) => return e.into(),
     };
     match PARSEC_BASIC_CLIENT.read().unwrap().psa_verify_hash(
-        key_slot_to_key_name(key_slot),
+        &key_slot_to_key_name(key_slot),
         std::slice::from_raw_parts(p_hash, hash_length),
         alg,
         std::slice::from_raw_parts(p_signature, signature_length),

--- a/src/key_management.rs
+++ b/src/key_management.rs
@@ -54,7 +54,7 @@ unsafe extern "C" fn p_import(
     };
     *bits = attributes.bits;
     match PARSEC_BASIC_CLIENT.read().unwrap().psa_import_key(
-        key_slot_to_key_name(key_slot),
+        &key_slot_to_key_name(key_slot),
         std::slice::from_raw_parts(data, data_length),
         attributes,
     ) {
@@ -78,7 +78,7 @@ unsafe extern "C" fn p_generate(
     match PARSEC_BASIC_CLIENT
         .read()
         .unwrap()
-        .psa_generate_key(key_slot_to_key_name(key_slot), attributes)
+        .psa_generate_key(&key_slot_to_key_name(key_slot), attributes)
     {
         Ok(_) => PSA_SUCCESS,
         Err(e) => client_error_to_psa_status(e),
@@ -93,7 +93,7 @@ unsafe extern "C" fn p_destroy(
     match PARSEC_BASIC_CLIENT
         .read()
         .unwrap()
-        .psa_destroy_key(key_slot_to_key_name(key_slot))
+        .psa_destroy_key(&key_slot_to_key_name(key_slot))
     {
         Ok(_) => PSA_SUCCESS,
         Err(e) => client_error_to_psa_status(e),
@@ -110,7 +110,7 @@ unsafe extern "C" fn p_export_public(
     let key_material = match PARSEC_BASIC_CLIENT
         .read()
         .unwrap()
-        .psa_export_public_key(key_slot_to_key_name(key))
+        .psa_export_public_key(&key_slot_to_key_name(key))
     {
         Ok(key) => key,
         Err(e) => return client_error_to_psa_status(e),


### PR DESCRIPTION
- `parsec-client` - `0.12.0` -> `0.13.0`
- `psa-crypto` - `0.8.0` -> `0.9.0`
- Fix compilation errors
- Update Travis CI to use Mbed TLS v2.27.0

Ref: [Mbed TLS v2.27.0](https://github.com/ARMmbed/mbedtls/releases/tag/v2.27.0)