### PR TITLE
Use mbedtls 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Download Mbed Crypto
-        run: git clone -b mbedtls-2.27.0 https://github.com/ARMmbed/mbedtls.git
+        run: git clone -b v3.0.0 https://github.com/ARMmbed/mbedtls.git
       - name: armv7-unknown-linux-gnueabihf
         run: |
           rustup target add armv7-unknown-linux-gnueabihf

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
 # Compile Mbed Crypto for the test application
   - git clone https://github.com/ARMmbed/mbedtls.git
   - pushd mbedtls
-  - git checkout mbedtls-2.27.0
+  - git checkout v3.0.0
   - ./scripts/config.py crypto
   - ./scripts/config.py set MBEDTLS_PSA_CRYPTO_SE_C
   - SHARED=1 make

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -14,7 +14,7 @@ then
 	git clone https://github.com/ARMmbed/mbedtls.git
 fi
 pushd mbedtls
-git checkout mbedtls-2.27.0
+git checkout v3.0.0
 popd
 
 #################

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![deny(
     nonstandard_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,


### PR DESCRIPTION
The psa-crypto crate is using mbedtls 3.0.0 which has few header files that are missing in mbedtls 2.27.0. As se driver uses psa-crypto internally we need to migrate to 3.0.0.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>