### PR TITLE
Pin down psa-crypto-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["staticlib"]
 parsec-client = "0.13.0"
 lazy_static = "1.4.0"
 psa-crypto = { version = "0.9.0", default-features = false, features = ["interface"] }
+psa-crypto-sys = { version = "=0.9.1", default-features = false, features = ["interface"] }
 log = "0.4.11"
 env_logger = { version = "0.7.1", optional = true }
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -66,9 +66,8 @@ MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release
 make -C ci/c-tests run MBED_TLS_PATH=$(pwd)/mbedtls
 
 # Check that Parsec was called by checking if the service contains the key
-# this is done by checking if the mappings folder is empty.
-# Maybe use parsec-tool instead?
-[ "$(ls -A /tmp/mappings)" ]
+cargo install --locked parsec-tool
+[ "$(RUST_LOG=error parsec-tool list-keys | wc -l)" -ne "0" ]
 
 # Kill Parsec for clean logs
 pkill parsec

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -32,7 +32,8 @@ fi
 # C Tests #
 ###########
 
-cp /tmp/NVChip .
+# Copy the TPM state for the SQLite KIM
+cp /tmp/sqlite/NVChip .
 # Start and configure TPM server
 tpm_server &
 sleep 5
@@ -43,7 +44,7 @@ tpm2_startup -T mssim
 mkdir /run/parsec
 
 # Install and run Parsec
-git clone --branch 0.6.0 https://github.com/parallaxsecond/parsec
+git clone --branch 1.0.0 https://github.com/parallaxsecond/parsec
 pushd parsec
 cargo build --features tpm-provider --release
 ./target/release/parsec -c ../ci/config.toml &

--- a/ci/config.toml
+++ b/ci/config.toml
@@ -18,13 +18,12 @@ timeout = 3000 # in milliseconds
 auth_type = "UnixPeerCredentials"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-# Warning: this path is used in the CI script
-store_path = "/tmp/mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Tpm"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "hex:74706d5f70617373" # "tpm_pass" in hex

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![deny(
     nonstandard_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,


### PR DESCRIPTION
Pinning the psa-crypto-sys version to allow v0.6 of the library to continue to function with MbedTLS v2.27 as advertised.