### PR TITLE
Pin version of psa-crypto-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["staticlib"]
 parsec-client = "0.13.0"
 lazy_static = "1.4.0"
 psa-crypto = { version = "0.9.0", default-features = false, features = ["interface"] }
+psa-crypto-sys = { version = "=0.9.1", default-features = false, features = ["interface"] }
 log = "0.4.11"
 env_logger = { version = "0.7.1", optional = true }
 


### PR DESCRIPTION
Set the version of psa-crypto-sys to be compatible with Mbed Crypto/Mbed TLS version 2.27.0